### PR TITLE
Add support for BaseDir to reference relative web path

### DIFF
--- a/src/RazorEmail/RazorEmail.csproj
+++ b/src/RazorEmail/RazorEmail.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Razor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\RazorEngine.3.0.8\lib\net40\System.Web.Razor.dll</HintPath>

--- a/src/RazorEmail/RazorMailer.cs
+++ b/src/RazorEmail/RazorMailer.cs
@@ -39,6 +39,9 @@ namespace RazorEmail
             if (baseDir.Contains("|DataDirectory|"))
                 baseDir = baseDir.Replace("|DataDirectory|", (string)AppDomain.CurrentDomain.GetData("DataDirectory"));
 
+            if (baseDir.Contains("~"))
+                baseDir = System.Web.Hosting.HostingEnvironment.MapPath(baseDir);
+
             return baseDir;
         }
 


### PR DESCRIPTION
This checks if the razor.email.base.dir path is "~/" format and maps the directory based on the web root. This allows you to use it in libraries outside of your direct web project, and also in Quartz jobs. 
