### PR TITLE
Adding support for embedded resources

### DIFF
--- a/src/RazorEmail/TemplateResolver.cs
+++ b/src/RazorEmail/TemplateResolver.cs
@@ -1,34 +1,79 @@
 ﻿using System;
+using System.Configuration;
 using System.IO;
+using System.Reflection;
 using RazorEngine.Templating;
 
 namespace RazorEmail
 {
     public class TemplateResolver : ITemplateResolver
     {
-        private readonly string baseDir;
+        protected internal readonly string BaseDir;
+		private readonly string _assemblyName;
+		private readonly Assembly _assembly;
+		private readonly bool _useEmbeddedResource;
 
-        public TemplateResolver(string baseDir)
+
+        public TemplateResolver(string baseDir = null)
         {
-            if (baseDir == null) throw new ArgumentNullException("baseDir");
+			if (baseDir == null)
+				baseDir = ConfigurationManager.AppSettings["razor.email.base.dir"];
 
-            this.baseDir = baseDir;
+			if (baseDir == null)
+				throw new ApplicationException("You must supply have a AppSetting called 'razor.email.base.dir'");
 
-            if (!Directory.Exists(baseDir))
-                throw new ArgumentException(String.Format("The template directory does not exist! - {0} , Full path: {1}", baseDir, Path.GetFullPath(baseDir)));
+			if (baseDir.Contains("|DataDirectory|"))
+				baseDir = baseDir.Replace("|DataDirectory|", (string)AppDomain.CurrentDomain.GetData("DataDirectory"));
+
+			if (baseDir.Contains("~"))
+				baseDir = System.Web.Hosting.HostingEnvironment.MapPath(baseDir);
+
+	        this.BaseDir = baseDir;
+
+			if (!String.IsNullOrEmpty(ConfigurationManager.AppSettings["razor.email.embedded"]))
+			{
+				var embedded = false;
+				Boolean.TryParse(ConfigurationManager.AppSettings["razor.email.embedded"], out embedded);
+				_useEmbeddedResource = embedded;
+				this._assemblyName = ConfigurationManager.AppSettings["razor.email.assemblyName"];
+				this._assembly = Assembly.Load(this._assemblyName);
+			}
+			else
+			{
+				if (!Directory.Exists(this.BaseDir))
+					throw new ArgumentException("The baseDir supplied doesn't exist: " + this.BaseDir);
+			}
+
         }
+
+	    public Stream GetStream(string name)
+	    {
+			if (this._useEmbeddedResource)
+			{
+				if (this._assembly == null)
+					throw new ApplicationException("Assembly not found");
+
+				return _assembly.GetManifestResourceStream(name);
+			}
+
+			var path = Path.Combine(BaseDir, name);
+			if (File.Exists(path))
+				return File.OpenRead(path);
+
+			if (File.Exists(path + ".cshtml"))
+				return File.OpenRead(path + ".cshtml");
+
+			return null;
+		}
 
         public string Resolve(string name)
         {
-            var path = Path.Combine(baseDir, name);
+	        var stream = this.GetStream(name);
+	        if (stream == null)
+		        return "";
+			using (var reader = new StreamReader(stream))
+			        return reader.ReadToEnd();
 
-            if (File.Exists(path))
-                return File.ReadAllText(path);
-
-            if (File.Exists(path + ".cshtml"))
-                return File.ReadAllText(path + ".cshtml");
-
-            return null;
         }
     }
 }


### PR DESCRIPTION
Refactored BaseDir slightly to use the the same TemplateResolver class to resolve the actual file served. Add two keys to your configr:

```
    <add key="razor.email.embedded" value="true"/>
    <add key="razor.email.assemblyName" value="Your.Assembly"/>
```

... and RazorMailer will attempt to pull the templates and config from the configured assembly as an embedded resource vs. from a file.

This change was specifically made to support RazorEmail in an Azure WebWorker role, which doesn't seem to support file-based templates.
